### PR TITLE
Tag received messages with system timestamp

### DIFF
--- a/lib/alsa-rawmidi/api.rb
+++ b/lib/alsa-rawmidi/api.rb
@@ -385,9 +385,9 @@ module AlsaRawMIDI
             subdev_count = API::Soundcard.get_subdevice_count(info) if i.zero?
             system_id = API::Soundcard.get_subdevice_id(soundcard_id, device_id, subdev_count, i)
             device_hash = {
-              :id => system_id,
-              :name => info[:name].to_s,
-              :subname => info[:subname].to_s
+              id: system_id,
+              name: info[:name].to_s,
+              subname: info[:subname].to_s
             }
             available << yield(device_hash)
             i += 1

--- a/lib/alsa-rawmidi/input.rb
+++ b/lib/alsa-rawmidi/input.rb
@@ -166,7 +166,9 @@ module AlsaRawMIDI
     # Collect messages from the system buffer
     # @return [Array<String>, nil]
     def populate_buffer(messages)
-      @buffer << get_message_formatted(messages, now) unless messages.nil?
+      unless messages.nil?
+        @buffer << get_message_formatted(messages, now)
+      end
     end
 
     # Convert a hex string to an array of numeric bytes eg "904040" -> [0x90, 0x40, 0x40]

--- a/lib/alsa-rawmidi/input.rb
+++ b/lib/alsa-rawmidi/input.rb
@@ -125,8 +125,8 @@ module AlsaRawMIDI
     # @return [Hash]
     def get_message_formatted(hexstring, timestamp)
       {
-        :data => hex_string_to_numeric_bytes(hexstring),
-        :timestamp => timestamp
+        data: hex_string_to_numeric_bytes(hexstring),
+        timestamp: timestamp
       }
     end
 

--- a/lib/alsa-rawmidi/soundcard.rb
+++ b/lib/alsa-rawmidi/soundcard.rb
@@ -7,8 +7,8 @@ module AlsaRawMIDI
     # @param [Integer] id
     def initialize(id)
       @subdevices = {
-        :input => [],
-        :output => []
+        input: [],
+        output: []
       }
       @id = id
       populate_subdevices
@@ -49,9 +49,9 @@ module AlsaRawMIDI
       when :output then Output
       end
       device_properties = {
-        :system_id => device_hash[:id],
-        :name => device_hash[:name],
-        :subname => device_hash[:subname]
+        system_id: device_hash[:id],
+        name: device_hash[:name],
+        subname: device_hash[:subname]
       }
       device_class.new(device_properties)
     end


### PR DESCRIPTION
Switch to tagging received messages with system timestamp rather than time since the device was opened